### PR TITLE
Add CompatHelper to keep track of dependency versions

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,28 @@
+name: CompatHelper
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Install CompatHelper"
+        run: |
+          using Pkg
+          Pkg.add("CompatHelper")
+        shell: julia --color=yes {0}
+      - name: "Run CompatHelper"
+        run: |
+          using CompatHelper
+          CompatHelper.main()
+        shell: julia --color=yes {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
CompatHelper lets us get automated PRs opened to bump the compat entries when new versions of the dependency packages are released, helping us stay up-to-date with the latest changes in them and ensuring we don't hold-back any package installs/updates.